### PR TITLE
Use https for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ Nie wolno w nim prowadzić prac projektowych!
 
 ## Licencja
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Switches the README license link from http:// to https://piecioshka.mit-license.org.